### PR TITLE
Add index to column

### DIFF
--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -11,5 +11,6 @@ CREATE TABLE IF NOT EXISTS `login_log` (
   `user_id` int,
   `login` varchar(255) NOT NULL,
   `ip` varchar(255) NOT NULL,
-  `succeeded` tinyint NOT NULL
+  `succeeded` tinyint NOT NULL,
+  KEY `idx_user_id`(`user_id`)
 ) DEFAULT CHARSET=utf8;


### PR DESCRIPTION
1500 前後から 3000 くらいに上がりました。
```
long_query_time=0.01
slow_query_log=1
slow_query_log_file=/var/lib/mysql/slow.log
log_queries_not_using_indexes=1
```
で 設定して slow.log が出なくなったので、コードや schema をいじらずに改善できるのはここまでかと...。